### PR TITLE
added get/put/del/etc helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ request({method: 'get', url: 'http://mydomain.com/api/v1/books/123', qs: {limit:
 });
 ``` 
 
-Note that cachemachine's request object only supports being called with a single 'object' or string parameter. It doesn't support Node.js streaming, nor can 
-you use the `.get`, `.post` helpers.
+Note that cachemachine's request object only supports being called with a single 'object' or string parameter or using the get/head/post/put/patch/del helper functions. It does **not** support Node.js streaming.
 
 ### How does it work?
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cachemachine",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "HTTP Request caching shim",
   "main": "app.js",
   "directories": {
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/glynnbird/cachemachine#readme",
   "dependencies": {
     "debug": "^2.2.0",
+    "extend": "^3.0.0",
     "redis": "^2.6.2",
     "request": "^2.74.0"
   },

--- a/test/request.js
+++ b/test/request.js
@@ -8,6 +8,17 @@ describe('cachemachine', function() {
     assert.equal(typeof request, 'function');
   });
 
+  it('should expose the correct functions', function() {
+    var request = require('../app.js')();
+    assert.equal(typeof request.get, 'function');
+    assert.equal(typeof request.head, 'function');
+    assert.equal(typeof request.post, 'function');
+    assert.equal(typeof request.put, 'function');
+    assert.equal(typeof request.patch, 'function');
+    assert.equal(typeof request.del, 'function');
+    assert.equal(typeof request['delete'], 'function');
+  });
+
   it('should make http requests and cache them', function(done) {
     var request = require('../app.js')();
     var mocks = nock('http://localhost')


### PR DESCRIPTION
Adds the helper functions like `request.get` to make the thing that cachemachine returns look more like a real request object.
